### PR TITLE
fix bug:(always use default.ini even cmdb.ini exist)

### DIFF
--- a/src/cmdb_be/config.py
+++ b/src/cmdb_be/config.py
@@ -10,15 +10,16 @@ class Config(object):
     def __init__(self, conf_dir, conf_file):
         self.conf_dir = conf_dir
         self.conf_file = conf_file
+        self.conf_path = os.path.join(self.conf_dir, self.conf_file)
         self.default_path = os.path.join(self.conf_dir, 'default.ini')
         self.cp = ConfigParser.ConfigParser()
-        if not os.path.exists(self.conf_file):
+        if not os.path.exists(self.conf_path):
             print "INFO: Not Found config file [%s], use [%s] instead" % (
-                os.path.join(self.conf_dir, self.conf_file),
+                self.conf_path,
                 self.default_path
                 )
-            self.conf_file = self.default_path
-        self.cp.read(self.conf_file)
+            self.conf_path = self.default_path
+        self.cp.read(self.conf_path)
 
     def conf_sections(self):
         return self.cp.sections()
@@ -27,7 +28,7 @@ class Config(object):
         if section in self.conf_sections():
             return self.cp.options(section)
         else:
-            print "%s have no conf section %s" % (self.conf_file, section)
+            print "%s have no conf section %s" % (self.conf_path, section)
 
     def get_config(self, section, option):
         if option in self.conf_options(section):


### PR DESCRIPTION
之前判断指定的配置文件是否存在时出现错误，判断结果永远为假，导致只会使用default.ini，通过修改判断参数改正